### PR TITLE
Update README and device selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Ignore Python cache and logs
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# Virtual environment directories
+venv/
+.env/
+
+# Dataset downloads
+/data/
+
+# Training outputs
+*/output/
+*.pt
+*.png
+*.gif
+
+# OS files
+.DS_Store

--- a/LatentDiffusionModel/v3/script_model_train_test.py
+++ b/LatentDiffusionModel/v3/script_model_train_test.py
@@ -1120,8 +1120,14 @@ def main():
     """Main function to run the entire pipeline non-interactively"""
     print("Starting class-conditional diffusion model for Fashion MNIST")
 
-    # Set device
-    device = torch.device("mps" if torch.mps.is_available() else "cpu")
+    # Set device with priority CUDA > MPS > CPU
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
+
     print(f"Using device: {device}")
 
     # Create results directory

--- a/README.md
+++ b/README.md
@@ -16,16 +16,15 @@ pip install torch torchvision matplotlib numpy tqdm scikit-learn
 Python 3.8 or later and a CUDA-capable GPU are recommended for training but are not strictly required.
 
 ## Quick start
-To train the latest latent diffusion model:
+To train the latest latent diffusion model and generate example outputs:
 ```bash
 cd LatentDiffusionModel/v3
-python script_model_train_test.py --train
+python script_model_train_test.py
 ```
-After training, generate samples from a saved checkpoint:
-```bash
-python script_model_train_test.py --generate --model-path <checkpoint>
-```
-See the README inside each subdirectory for additional options and explanations.
+The script will automatically train the autoencoder and diffusion model if
+no checkpoints are found and then produce a set of sample visualisations.
+See the README inside each subdirectory for additional options and
+explanations.
 
 ## Dataset
 The models use the [Fashion-MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset of 28×28 grayscale clothing images.  The dataset will be downloaded automatically by the provided scripts if it is not already present on your system.


### PR DESCRIPTION
## Summary
- add `.gitignore` to prevent committing data and generated outputs
- clarify quick start instructions in the README
- improve device selection logic in the main training script

## Testing
- `python -m py_compile LatentDiffusionModel/v3/script_model_train_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68487bd903608330b53b0c340c204988